### PR TITLE
Fix redirection to stderr using `^` for deprecation

### DIFF
--- a/functions/__tmux_rename_window.fish
+++ b/functions/__tmux_rename_window.fish
@@ -19,7 +19,7 @@ function __github_repo_name
 end
 
 function __tmux_rename_window
-    if not command tmux info > /dev/null ^ /dev/null
+    if not command tmux info > /dev/null 2>/dev/null
         return 1
     end
 


### PR DESCRIPTION
`^` character to redirect to stderr will be disabled completely.

see also:
  https://fishshell.com/docs/current/relnotes.html#deprecations-and-removed-features
  https://github.com/fish-shell/fish-shell/issues/7105